### PR TITLE
Bugfixes: init timeout & exit event

### DIFF
--- a/taclib/config_default.yaml
+++ b/taclib/config_default.yaml
@@ -5,3 +5,4 @@ environment: {}
 resources: {}
 pod_spec: {}
 job_spec: {}
+init_timeout: 300

--- a/taclib/container.py
+++ b/taclib/container.py
@@ -400,7 +400,7 @@ class K8sClient(ContainerClient):
                 )
 
     def get_exit_info(self, container):
-        self._wait_for_status(container, "Completed")
+        self._wait_for_status(container, "Succeeded")
         pod = self._get_pod(container)
         pod_status = pod.status
         container_status = pod_status.container_statuses[0]


### PR DESCRIPTION
Fixes two things:
1. Increases timeout until control is handed off to log generator. This should avoid 409 exception because we try to get logs to early. While image is still being pulled.
2. Wait for correct status to retrieve pod exit information
