### PR TITLE
Fix test_warn_pod_status_timeout

### DIFF
--- a/taclib/container.py
+++ b/taclib/container.py
@@ -381,11 +381,13 @@ class K8sClient(ContainerClient):
             self._warn_pod_status_timeout(desired_status, status)
             return False
 
-    def _warn_pod_status_timeout(self, desired_status, status):
+    @staticmethod
+    def _warn_pod_status_timeout(desired_status, status):
+        logger = getLogger(__name__)
         if (
             desired_status != "Running" or status != "Succeeded"
         ) and desired_status != status:
-            self.taclib_log.warning(
+            logger.warning(
                 "Timeout while waiting for status %s! Pod had status:"
                 " %s" % (desired_status, status)
             )

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,5 +1,4 @@
 import pytest
-
 from taclib.container import K8sClient
 
 
@@ -19,7 +18,7 @@ from taclib.container import K8sClient
     ],
 )
 def test_warn_pod_status_timeout(desired, actual, warn, caplog):
-    K8sClient()._warn_pod_status_timeout(desired, actual)
+    K8sClient._warn_pod_status_timeout(desired, actual)
     if warn:
         assert "Timeout while waiting for status" in caplog.text
     else:


### PR DESCRIPTION
Instantiate the K8sClient in the unit tests assumes the test environment has access to some cluster config which is not the case in the Code Build