### PR TITLE
Add metadata to pod spec

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,10 @@ class KubernetesTestTask(KubernetesTask):
         return "drtools/random-task"
 
     @property
+    def pod_metadata(self):
+        return {"annotations": {"safe-to-evict": "true"}}
+
+    @property
     def configuration(self):
         env = ["NLOGS=2"]
         if self.fail:

--- a/tests/test_k8s_client.py
+++ b/tests/test_k8s_client.py
@@ -6,24 +6,24 @@ from taclib.container import K8sClient
 @mock.patch("taclib.container.k8s_config")
 def test_make_jobspec(patched_config):
     client = K8sClient()
-
     job_spec = client._make_job_spec(
-        "test-job",
-        "drtools/job:0.1.0",
-        ["echo", "hello", "world"],
-        {},
-        ["PYTHONUNBUFFERED=True"],
-        {"labels": {"mypipeline": "test"}},
-        {
+        name="test-job",
+        image="drtools/job:0.1.0",
+        cmd=["echo", "hello", "world"],
+        resources={},
+        env=["PYTHONUNBUFFERED=True"],
+        job_metadata={"labels": {"mypipeline": "test"}},
+        pod_metadata={"annotations": {"safe-to-evict": "true"}},
+        pod_spec_kwargs={
             "volumes": [
                 {
                     "name": "az-secrets-volume",
                     "secret": {"secret_name": "az-credentials-yaml"},
                 }
-            ]
+            ],
         },
-        {},
-        {
+        job_spec_kwargs={},
+        container_spec_kwargs={
             "volume_mounts": [
                 {
                     "name": "az-secrets-volume",
@@ -38,6 +38,8 @@ def test_make_jobspec(patched_config):
         "name": "az-secrets-volume",
         "secret": {"secret_name": "az-credentials-yaml"},
     }
+    assert job_spec.metadata.labels == {"mypipeline": "test"}
+    assert job_spec.spec.template.metadata.annotations == {"safe-to-evict": "true"}
     assert container["env"][0] == {
         "name": "PYTHONUNBUFFERED",
         "value": "True",
@@ -50,3 +52,5 @@ def test_make_jobspec(patched_config):
         "name": "az-secrets-volume",
     }
     assert container["image_pull_policy"] == "IfNotPresent"
+
+

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -77,6 +77,23 @@ def test_task_node_selector(mock):
     task = KubernetesTestTask(out="/tmp/test", node_selector="memory=huge")
     assert task.pod_spec_kwargs["node_selector"] == {"memory": "huge"}
 
+    task = KubernetesTestTask(out="/tmp/test", node_selector="memory=huge,lbl=label_1")
+    assert task.pod_spec_kwargs["node_selector"] == {"memory": "huge", "lbl": "label_1"}
+
+
+@mock.patch("taclib.task.KubernetesTask.CLIENT", autospec=K8sClient)
+def test_task_annotations(mock):
+    task = KubernetesTestTask(out="/tmp/test", annotations="safe-to-evict=true")
+    assert task.pod_spec_kwargs["annotations"] == {"safe-to-evict": "true"}
+
+    task = KubernetesTestTask(
+        out="/tmp/test", annotations="safe-to-evict=true,base-image=image"
+    )
+    assert task.pod_spec_kwargs["annotations"] == {
+        "safe-to-evict": "true",
+        "base-image": "image",
+    }
+
 
 @mock.patch("taclib.task.KubernetesTask.CLIENT", autospec=K8sClient)
 def test_task_namespace(mock):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -82,20 +82,6 @@ def test_task_node_selector(mock):
 
 
 @mock.patch("taclib.task.KubernetesTask.CLIENT", autospec=K8sClient)
-def test_task_annotations(mock):
-    task = KubernetesTestTask(out="/tmp/test", annotations="safe-to-evict=true")
-    assert task.pod_spec_kwargs["annotations"] == {"safe-to-evict": "true"}
-
-    task = KubernetesTestTask(
-        out="/tmp/test", annotations="safe-to-evict=true,base-image=image"
-    )
-    assert task.pod_spec_kwargs["annotations"] == {
-        "safe-to-evict": "true",
-        "base-image": "image",
-    }
-
-
-@mock.patch("taclib.task.KubernetesTask.CLIENT", autospec=K8sClient)
 def test_task_namespace(mock):
     task = KubernetesTestTask(out="/tmp/test", k8s_namespace="production")
     assert task.k8s_namespace == "production"
@@ -116,6 +102,7 @@ def test_task_configuration(mock):
         },
         "environment": ["NLOGS=2"],
         "resources": OrderedDict(),
+        "pod_metadata":  {"annotations": {"safe-to-evict": "true"}},
         "pod_spec_kwargs": OrderedDict(
             [("node_selector", {"memory": "huge"}), ("service_account_name", "task-sa")]
         ),


### PR DESCRIPTION
This PR enables adding metadata to pod specifications. 

The metadata can be add with the task property or via config file:
```
@property
def pod_metadata(self):
       return {"annotations": {"annot": "my-annotation"}}
```

